### PR TITLE
Invalidate request can't work with filesystem cache

### DIFF
--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -201,7 +201,7 @@ export class FilesystemCache {
   }
 
   private async handleInvalidateRequest(ctx: Koa.Context, url: string) {
-    let cacheKey = this.sanitizeKey(url);
+    let cacheKey = this.sanitizeKey(ctx.url);
 
     // remove /invalidate/ from key, only at the start
     if (cacheKey.startsWith('/invalidate/')) {

--- a/src/filesystem-cache.ts
+++ b/src/filesystem-cache.ts
@@ -200,7 +200,7 @@ export class FilesystemCache {
     return cacheKey
   }
 
-  private async handleInvalidateRequest(ctx: Koa.Context, url: string) {
+  private async handleInvalidateRequest(ctx: Koa.Context) {
     let cacheKey = this.sanitizeKey(ctx.url);
 
     // remove /invalidate/ from key, only at the start


### PR DESCRIPTION
example url  : https://www.careline.com.tw/CareLineTravel/activity

Reproduce steps :
 - send a  render request through middleware
 -  - cache key
![image](https://user-images.githubusercontent.com/6021919/123935109-80a54980-d9c6-11eb-9a94-b551d0152a86.png)

- send a invalidate request through middleware
- - cache key
- 
![image](https://user-images.githubusercontent.com/6021919/123935335-b5190580-d9c6-11eb-80a4-19d4643b2942.png)

--- 
My solution
 - make the cache key is same between render and invalidate request
 
![image](https://user-images.githubusercontent.com/6021919/123935674-032e0900-d9c7-11eb-8dcc-bd81608e3c0b.png)
